### PR TITLE
Null check on the type property of sparkplug B message

### DIFF
--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -1481,6 +1481,8 @@ async function sparkplugProcess (
 
       // process MQTT Sparkplug B messages (coming from other devices)
       spClient.handle.on('message', function (topic, payload, topicInfo) {
+        payload.metrics = payload?.metrics // null check filter
+          ?.filter(metric => !(metric?.type === undefined || metric?.type === null))
         Log.log(logModS + 'Event: Sparkplug B message on topic: ' + topic)
 
         if (Log.logLevelCurrent >= Log.levelDetailed) {


### PR DESCRIPTION
Fields that do not conform to the sparkplug B specification will be resolved to `undefined` by protobuf.

This is the implementation of `sparkplug-payload` module:
 `sparkplug-payload/lib/sparkplugbpayload.js:719`
```js
exports.decodePayload = function(proto) {
  var sparkplugPayload = Payload.decode(proto),
      payload = {};
  ...
```

In your implementation of `mqtt-sparkplug`, you directly call `toLowerCase` in the `mitric.type` object without doing any null check.

It is very likely that the module will be terminated directly after receiving the spark plug B message which is not successfully parsed due to non-compliance with the specification.I don't think we can take it for granted that the device program will not provide non-compliance messages.

The problem code is here: 
`josn-scada/src/mqtt-sparkplug/index.js:1732`
```js
switch (metric.type.toLowerCase()) {
  case 'template':
    type = 'json'
  ...
```

In this submission, I use the filter method to filter out non-conforming messages. Is this a good solution?

In the end, It's really a great project, but unfortunately typescript isn't used, otherwise these problems would be easily detected by typescript's type checking during the coding phase.