### PR TITLE
fix(server_realtime_auth): array index out of range when tag number is 0

### DIFF
--- a/src/server_realtime_auth/app/controllers/auth.controller.js
+++ b/src/server_realtime_auth/app/controllers/auth.controller.js
@@ -61,7 +61,7 @@ exports.createTag = async (req, res) => {
     .select( "_id" )
     .sort({ _id: -1 })
     .limit(1)
-  if (resBiggest) 
+  if (resBiggest && resBiggest.length > 0) 
   if ("_id" in resBiggest[0])
     biggestTagId = parseFloat(resBiggest[0]._id)
   console.log(biggestTagId)


### PR DESCRIPTION
When the number of tags is 0, we will get an empty array, so we need to do some checks here.