### PR TITLE
mqtt sparkplug - negative and big numbers

### DIFF
--- a/src/mqtt-sparkplug/cast.js
+++ b/src/mqtt-sparkplug/cast.js
@@ -12,40 +12,31 @@ const Long = require("long");
  *
  * @param {string} type MQTT sparkplug metric datatype
  * @param {number|string|Long} value
- * @returns {number|Long|bigint|Date|string|Boolean}
+ * @returns {number|Long|Date|string|Boolean}
  */
 const castSparkplugValue = (type, value) => {
   switch (type.toLowerCase()) {
     case "int8":
     case "int16":
     case "int32":
-      return new Int32Array([value])[0]; // number -1
-      // return Long.fromValue(value, false).toSigned().toInt(); // number -1
+      return new Int32Array([value])[0];
 
     case "int64":
-      return Long.fromValue(value, false).toSigned(); // object Long { low: -1, high: -1, unsigned: false }
-      // return Long.fromValue(value, false).toSigned().toNumber(); // number -1
-      // return Long.fromValue(value, false).toSigned().toString(); // string "-1"
-      // return BigInt(Long.fromValue(value, false).toSigned().toString()); // bigint -1n
+      return Long.fromValue(value, false).toSigned();
 
     case "uint8":
     case "uint16":
     case "uint32":
-      return new Uint32Array([value])[0]; // number 4294967295
-      // return Long.fromValue(value, true).toUnsigned().toInt(); // number 4294967295
+      return new Uint32Array([value])[0];
 
     case "uint64":
-      return Long.fromValue(value, true).toUnsigned(); // object Long { low: -1, high: -1, unsigned: true }
-      // return Long.fromValue(value, true).toUnsigned().toNumber(); //         number  18446744073709552000  !!! warning number is truncated !!!
-      // return Long.fromValue(value, true).toUnsigned().toString(); //         string "18446744073709551615"
-      // return BigInt(Long.fromValue(value, true).toUnsigned().toString()); // bigint  18446744073709551615n
+      return Long.fromValue(value, true).toUnsigned();
 
     case "datetime":
-      return new Date(Long.fromValue(value, true).toUnsigned().toNumber()); // object Date
+      return new Date(Long.fromValue(value, true).toUnsigned().toNumber());
 
     case "boolean":
-      return Boolean(value); // boolean false or true
-      // return +Boolean(value); // number 0 or 1
+      return Boolean(value); // boolean false or true TODO return number 0 or 1 instead?
   }
   return value;
 };

--- a/src/mqtt-sparkplug/cast.js
+++ b/src/mqtt-sparkplug/cast.js
@@ -1,0 +1,53 @@
+const Long = require("long");
+
+/**
+ * MQTT sparkplug's numeric datatypes for metrics int8, int16, int32
+ * are encoded using protobuf's uint32 type.
+ * However tahu's sparkplug-payload library won't convert negative values back,
+ * eg, if metric is {name: "metric", type: "Int8", value: -1}, the decoded value is 4294967295 instead of -1
+ *
+ * This does not "clamp" values
+ *
+ * 64bits return Long objects TODO should return a number?
+ *
+ * @param {string} type MQTT sparkplug metric datatype
+ * @param {number|string|Long} value
+ * @returns {number|Long|bigint|Date|string|Boolean}
+ */
+const castSparkplugValue = (type, value) => {
+  switch (type.toLowerCase()) {
+    case "int8":
+    case "int16":
+    case "int32":
+      return new Int32Array([value])[0]; // number -1
+      // return Long.fromValue(value, false).toSigned().toInt(); // number -1
+
+    case "int64":
+      return Long.fromValue(value, false).toSigned(); // object Long { low: -1, high: -1, unsigned: false }
+      // return Long.fromValue(value, false).toSigned().toNumber(); // number -1
+      // return Long.fromValue(value, false).toSigned().toString(); // string "-1"
+      // return BigInt(Long.fromValue(value, false).toSigned().toString()); // bigint -1n
+
+    case "uint8":
+    case "uint16":
+    case "uint32":
+      return new Uint32Array([value])[0]; // number 4294967295
+      // return Long.fromValue(value, true).toUnsigned().toInt(); // number 4294967295
+
+    case "uint64":
+      return Long.fromValue(value, true).toUnsigned(); // object Long { low: -1, high: -1, unsigned: true }
+      // return Long.fromValue(value, true).toUnsigned().toNumber(); //         number  18446744073709552000  !!! warning number is truncated !!!
+      // return Long.fromValue(value, true).toUnsigned().toString(); //         string "18446744073709551615"
+      // return BigInt(Long.fromValue(value, true).toUnsigned().toString()); // bigint  18446744073709551615n
+
+    case "datetime":
+      return new Date(Long.fromValue(value, true).toUnsigned().toNumber()); // object Date
+
+    case "boolean":
+      return Boolean(value); // boolean false or true
+      // return +Boolean(value); // number 0 or 1
+  }
+  return value;
+};
+
+module.exports = { castSparkplugValue };

--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -665,18 +665,18 @@ function getMetricCommandPayload (cmd) {
   switch (cmd.protocolSourceASDU.toLowerCase()) {
     case 'int8':
       value = parseInt(cmd.value)
-      if (value > Math.pow(2, 8) - 1) value = Math.pow(2, 8) - 1
-      else if (value < Math.pow(2, 8)) value = Math.pow(2, 8)
+      if (value > Math.pow(2, 7) - 1) value = Math.pow(2, 7) - 1
+      else if (value < -Math.pow(2, 7)) value = -Math.pow(2, 7)
       break
     case 'int16':
       value = parseInt(cmd.value)
-      if (value > Math.pow(2, 16) - 1) value = Math.pow(2, 16) - 1
-      else if (value < Math.pow(2, 16)) value = Math.pow(2, 16)
+      if (value > Math.pow(2, 15) - 1) value = Math.pow(2, 15) - 1
+      else if (value < -Math.pow(2, 15)) value = -Math.pow(2, 15)
       break
     case 'int32':
       value = parseInt(cmd.value)
-      if (value > Math.pow(2, 32) - 1) value = Math.pow(2, 32) - 1
-      else if (value < Math.pow(2, 32)) value = Math.pow(2, 32)
+      if (value > Math.pow(2, 31) - 1) value = Math.pow(2, 31) - 1
+      else if (value < -Math.pow(2, 31)) value = -Math.pow(2, 31)
       break
     case 'int':
     case 'int64':
@@ -684,17 +684,17 @@ function getMetricCommandPayload (cmd) {
       break
     case 'uint8':
       value = parseInt(cmd.value)
-      if (value > Math.pow(2, 8)) value = Math.pow(2, 8)
+      if (value > Math.pow(2, 8) - 1) value = Math.pow(2, 8) - 1
       else if (value < 0) value = 0
       break
     case 'uint16':
       value = parseInt(cmd.value)
-      if (value > Math.pow(2, 16)) value = Math.pow(2, 16)
+      if (value > Math.pow(2, 16) - 1) value = Math.pow(2, 16) - 1
       else if (value < 0) value = 0
       break
     case 'uint32':
       value = parseInt(cmd.value)
-      if (value > Math.pow(2, 32)) value = Math.pow(2, 32)
+      if (value > Math.pow(2, 32) - 1) value = Math.pow(2, 32) - 1
       else if (value < 0) value = 0
       break
     case 'uint64':

--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -1713,7 +1713,7 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
 
     // map alias to object address for later query
     if ('alias' in metric) {
-      let alias = metric.alias.toNumber() // warning numbers bigger than Number.MAX_SAFE_INTEGER are not safe
+      let alias = metric.alias
       let device = DevicesList[deviceLocator]
       if (!device) {
         // device not yet included
@@ -1722,7 +1722,7 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
       device.mapAliasToObjectAddress['a' + alias.toString()] = objectAddress
     }
   } else if ('alias' in metric) {
-    let alias = metric.alias.toNumber() // warning numbers bigger than Number.MAX_SAFE_INTEGER are not safe
+    let alias = metric.alias
     let device = DevicesList[deviceLocator]
     if (device)
       objectAddress =
@@ -1733,7 +1733,7 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
       // alias not mapped
       Log.log(
         'Sparkplug - Unmapped metric alias=' +
-          alias +
+          alias.toString() +
           ' device=' +
           deviceLocator,
         Log.levelDetailed

--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -35,6 +35,7 @@ const LoadConfig = require('./load-config')
 const Redundancy = require('./redundancy')
 const AutoTag = require('./auto-tag')
 const { timeEnd } = require('console')
+const { castSparkplugValue: castSparkplugValue } = require('./cast')
 
 const SparkplugNS = 'spBv1.0'
 const DevicesList = []
@@ -1712,8 +1713,7 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
 
     // map alias to object address for later query
     if ('alias' in metric) {
-      let alias =
-        (metric.alias.low >>> 0) + (metric.alias.high >>> 0) * Math.pow(2, 32)
+      let alias = metric.alias.toNumber() // warning numbers bigger than Number.MAX_SAFE_INTEGER are not safe
       let device = DevicesList[deviceLocator]
       if (!device) {
         // device not yet included
@@ -1722,8 +1722,7 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
       device.mapAliasToObjectAddress['a' + alias.toString()] = objectAddress
     }
   } else if ('alias' in metric) {
-    let alias =
-      (metric.alias.low >>> 0) + (metric.alias.high >>> 0) * Math.pow(2, 32)
+    let alias = metric.alias.toNumber() // warning numbers bigger than Number.MAX_SAFE_INTEGER are not safe
     let device = DevicesList[deviceLocator]
     if (device)
       objectAddress =
@@ -1791,11 +1790,11 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
           for (let j = 0; j < metric.value.rows.length; j++) {
             let r = {}
             for (let i = 0; i < metric.value.numOfColumns; i++) {
-              let mv = metric.value.rows[j][i]
+              let mv = castSparkplugValue(metric.value.types[i], metric.value.rows[j][i])
               switch (metric.value.types[i].toLowerCase()) {
                 case 'int64':
                 case 'uint64':
-                  mv = (mv.low >>> 0) + (mv.high >>> 0) * Math.pow(2, 32)
+                  mv = mv.toNumber() // warning number may be truncated
                   break
                 default:
                   break
@@ -1845,6 +1844,10 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
         } catch (e) {}
       }
       break
+    case 'int8':
+    case 'uint8':
+    case 'int16':
+    case 'uint16':
     case 'int32':
     case 'uint32':
     case 'float':
@@ -1857,7 +1860,7 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
         valueJson = 0
       } else {
         // metric does have a value
-        value = metric.value
+        value = castSparkplugValue(metric.type, metric.value)
         valueString = value.toString()
         valueJson = metric
       }
@@ -1872,12 +1875,13 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
         valueJson = 0
       } else {
         // metric does have a value
-        value =
-          (metric.value.low >>> 0) + (metric.value.high >>> 0) * Math.pow(2, 32)
+        value = castSparkplugValue(metric.type, metric.value)
+        value = value.toNumber() // warning number may be truncated
         valueString = value.toString()
         valueJson = metric
       }
       break
+    // case 'datetime': // TODO ??
   }
 
   if ('properties' in metric) {
@@ -2017,23 +2021,28 @@ async function ProcessDeviceCommand (
             valueJson = JSON.parse(metric.value)
           } catch (e) {}
           break
+        case 'int8':
+        case 'int16':
+        case 'uint8':
+        case 'uint16':
         case 'int32':
         case 'uint32':
         case 'float':
         case 'double':
-          value = element.kconv1 * metric.value + element.kconv2
+          value = castSparkplugValue(metric.type, metric.value)
+          value = element.kconv1 * value + element.kconv2
           valueString = value.toString()
           valueJson = value
           break
         case 'int64':
         case 'uint64':
-          value =
-            (metric.value.low >>> 0) +
-            (metric.value.high >>> 0) * Math.pow(2, 32)
-          value = element.kconv1 * value + element.kconv2
+          value = castSparkplugValue(metric.type, metric.value)
+          value = value.mul(element.kconv1).add(element.kconv2) // safe Long object
+          value = value.toNumber() // warning unsafe number
           valueString = value.toString()
           valueJson = value
           break
+        // case 'datetime': 
         default:
           valueString = JSON.stringify(metric)
           valueJson = metric


### PR DESCRIPTION
There are a few issues resulting from a buggy implementation of the `sparkplug-payload` library together with JS quirks, that makes decoding some values fail in the `mqtt-sparkplug` process.

# negative numbers

Because Sparkplug datatypes `int8`, `int16`, `int32` are encoded as Protobuf `uint32`,
and that the `sparkplug-payload` library does not "decode" these back to signed numbers,
the `mqtt-sparkplug` module unfortunatly "decodes" a `int8` as `4294967295` where `-1` was intended!

There is a problem with signed `int64` too:


# 64bit numbers aka Long numbers

The other issue is [the maximum safe integer in JavaScript is 2**53 - 1](https://www.npmjs.com/package/long#user-content-background).
In order to manipulate 64 bits (and not truncate to [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)) the Protobuf library decodes their own `uint64` into [Long objects](https://www.npmjs.com/package/long)

The trouble is that statements such as `(mv.low >>> 0) + (mv.high >>> 0) * Math.pow(2, 32)` 
- can't support numbers larger than `MAX_SAFE_INTEGER`
- negative numbers decoding fails too

I propose a fix where negative numbers will be handled. Still, numbers larger than `MAX_SAFE_INTEGER` will not be properly handled

---

Until the fix is published (the [PR I suggested to resolve the issue has just been accepted and merged into the develop branch](https://github.com/eclipse/tahu/pull/179/files#diff-62d4f1791f3481d9ef70d0b7ef97b6a9d34e58ad324e225ea65bd9c571d1fcbeR114)), I'd like to know what you think of the workaround I propose here.

Thank you for your great work!