### PR TITLE
[mqtt-sparkplug]: fix TLS support

### DIFF
--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -1012,7 +1012,7 @@ function getSparkplugConfig (connection) {
 
   let secOpts = {}
   if (connection.useSecurity) {
-    certOpts = {}
+    let certOpts = {}
     if (connection.pfxFilePath !== '') {
       certOpts = {
         pfx: Fs.readFileSync(connection.pfxFilePath),

--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -1013,18 +1013,22 @@ function getSparkplugConfig (connection) {
   let secOpts = {}
   if (connection.useSecurity) {
     let certOpts = {}
-    if (connection.pfxFilePath !== '') {
+    if ((connection.pfxFilePath !== '') && Fs.existsSync(connection.pfxFilePath)) {
       certOpts = {
         pfx: Fs.readFileSync(connection.pfxFilePath),
         passphrase: connection.passphrase
       }
     } else {
-      certOpts = {
-        ca: Fs.readFileSync(connection.rootCertFilePath),
-        key: Fs.readFileSync(connection.privateKeyFilePath),
-        cert: Fs.readFileSync(connection.localCertFilePath),
-        passphrase: connection.passphrase
+      if ((connection.rootCertFilePath !== '') && Fs.existsSync(connection.rootCertFilePath)) {
+        certOpts.ca = Fs.readFileSync(connection.rootCertFilePath)
       }
+      if ((connection.privateKeyFilePath !== '') && Fs.existsSync(connection.privateKeyFilePath)) {
+        certOpts.key = Fs.readFileSync(connection.privateKeyFilePath)
+      }
+      if ((connection.localCertFilePath !== '') && Fs.existsSync(connection.localCertFilePath)) {
+        certOpts.cert = Fs.readFileSync(connection.localCertFilePath)
+      }
+      certOpts.passphrase = connection.passphrase
     }
 
     secOpts = {


### PR DESCRIPTION
The MQTT-Sparkplug driver won't run when TLS is enabled (at least in NodeJS 16) because variable `certOpts` is not explicitly declared.

```
2022-10-27T09:03:44.253Z - Config - Config File: ../../conf/json-scada.json
2022-10-27T09:03:44.256Z - Config - {json:scada} - MQTT-Sparkplug-B Client Driver Version 0.1.4
2022-10-27T09:03:44.256Z - Config - Instance: 1
2022-10-27T09:03:44.256Z - Config - Log level: 1
2022-10-27T09:03:44.257Z - MongoDB - Connecting to MongoDB server...
2022-10-27T09:03:44.311Z - MongoDB - Connected correctly to MongoDB server
2022-10-27T09:03:44.337Z - Connection - Connection Number: 1200
2022-10-27T09:03:44.342Z - Auto Key - Initial value: 1200002388
2022-10-27T09:03:44.343Z - Redundancy - Process Inactive
2022-10-27T09:03:44.351Z - Redundancy - Node activated!
2022-10-27T09:03:49.345Z - Redundancy - Process Active
2022-10-27T09:03:49.347Z - MQTT Client - Creating client...
2022-10-27T09:03:49.347Z - MQTT Client - Parameter error. certOpts is not defined
```

All this fix does is delcare the variable `certOpts`.
