### PR TITLE
MQTT sparkplug: support for Dataset metrics

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -140,7 +140,8 @@ Example document.
 * _**_supervisedOfCommand_**_ [Double] - Key (\_id) pointing to a supervised point related to a command point (tag where the command feedback manifests). Only meaningful for _origin=command_ points (put zero here for other origins). Put value zero for this parameter when the command point does not have a related supervised (not recommended as this is a blind command with no feedback for the user). **Mandatory parameter**.
 * _**_location_**_ [GeoJSON] - Reserved for location coordinates. Currently not in use. Can be null. **Mandatory parameter**.
 * _**_isEvent_**_ [Boolean] - Flag meaning that only transitions OFF->ON for _type=digital_ matters for alarms and SOE (commonly used for electrical protection events). For _type=analog_ values it means that all valid changes of values should be recorded as SOE (future use). **Mandatory parameter**.
-* _**_unit_**_ [String] - Unit of measurement when _type=analog_. **Mandatory parameter**.
+* _**_unit_**_ [String] - Unit of measurement when _type=analog_ or _type=json_. **Mandatory parameter**.
+* * _**_samplingRate_**_ [String] - sampling rate when _type=json_.
 * _**_alarmState_**_ [Double] - Considered state for alarm (0=off=false, 1=on=true, 2=both states, 3=state OFF->ON transition, -1=no state produces alarms but alarms can be signaled by other means) when _type=digital_. **Mandatory parameter**.
 * _**_stateTextTrue_**_ [String] - Text for state true (numeric value not zero) when _type=digital_. Normally expressed as present tense (e.g. "ON"). **Mandatory parameter**.
 * _**_stateTextFalse_**_ [String] - Text for state false (numeric value zero) when _type=digital_. Normally expressed as present tense (e.g. "OFF").  **Mandatory parameter**.

--- a/src/mqtt-sparkplug/auto-tag.js
+++ b/src/mqtt-sparkplug/auto-tag.js
@@ -83,6 +83,7 @@ function NewTag () {
     parcels: null,
     priority: new Mongo.Double(0.0),
     protocolDestinations: null,
+    samplingRate: null,
     sourceDataUpdate: null,
     supervisedOfCommand: new Mongo.Double(0.0),
     substituted: false,
@@ -157,6 +158,10 @@ async function AutoCreateTag (data, connectionNumber, rtDataCollection) {
         newTag.eventTextTrue = "true"
         newTag.stateTextFalse = "false"
         newTag.stateTextTrue = "true"
+      }
+      if (newTag.type === 'json'){
+        newTag.unit = data?.unit || 'units'
+        newTag.samplingRate = data?.samplingRate
       }
       newTag.description = data?.description
       newTag.ungroupedDescription = data?.ungroupedDescription || data.protocolSourceObjectAddress

--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -1911,16 +1911,25 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
       catalogProperties.description = metric.metadata.description
 
     if ('properties' in metric) {
-      if ('description' in metric.properties) {
-        catalogProperties.description = metric.properties.description.value
+      for (const prop in metric.properties) {
+        switch(prop) {
+          case 'description':
+          case 'ungroupedDescription':
+          case 'group1':
+          case 'group2':
+          case 'group3':
+            catalogProperties[prop] = metric.properties[prop].value
+            break
+          case 'engUnit':
+          case 'unit':
+            catalogProperties.unit = metric.properties[prop].value
+            break
+          case 'sampling rate':
+          case 'samplingRate':
+            catalogProperties.samplingRate = metric.properties[prop].value
+            break
+        }
       }
-      catalogProperties.ungroupedDescription =
-        metric.properties?.ungroupedDescription?.value || ''
-      catalogProperties.group1 = metric.properties?.group1?.value || ''
-      catalogProperties.group2 = metric.properties?.group2?.value || ''
-      catalogProperties.group3 = metric.properties?.group3?.value || ''
-      if ('engUnit' in metric.properties)
-        catalogProperties.unit = metric.properties.engUnit?.value || 'units'
     }
     catalogProperties.commissioningRemarks =
       'Auto created by Sparkplug B driver - ' + new Date().toISOString()

--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -36,6 +36,7 @@ const Redundancy = require('./redundancy')
 const AutoTag = require('./auto-tag')
 const { timeEnd } = require('console')
 const { castSparkplugValue: castSparkplugValue } = require('./cast')
+const { camelCase } = require('lodash')
 
 const SparkplugNS = 'spBv1.0'
 const DevicesList = []
@@ -1912,7 +1913,7 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
 
     if ('properties' in metric) {
       for (const prop in metric.properties) {
-        switch(prop) {
+        switch(camelCase(prop)) {
           case 'description':
           case 'ungroupedDescription':
           case 'group1':
@@ -1924,7 +1925,6 @@ function queueMetric (metric, deviceLocator, isBirth, templateName) {
           case 'unit':
             catalogProperties.unit = metric.properties[prop].value
             break
-          case 'sampling rate':
           case 'samplingRate':
             catalogProperties.samplingRate = metric.properties[prop].value
             break

--- a/src/mqtt-sparkplug/package-lock.json
+++ b/src/mqtt-sparkplug/package-lock.json
@@ -12,6 +12,7 @@
         "fs": "*",
         "gridfs-stream": "^1.1.1",
         "jsonpath-plus": "^6.0.1",
+        "lodash": "^4.17.21",
         "mongodb": "^3.6.5",
         "mqtt": "^4.3.6",
         "queue-fifo": "^0.2.6",

--- a/src/mqtt-sparkplug/package.json
+++ b/src/mqtt-sparkplug/package.json
@@ -12,6 +12,7 @@
     "fs": "*",
     "gridfs-stream": "^1.1.1",
     "jsonpath-plus": "^6.0.1",
+    "lodash": "^4.17.21",
     "mongodb": "^3.6.5",
     "mqtt": "^4.3.6",
     "queue-fifo": "^0.2.6",


### PR DESCRIPTION
Here is my attempt at handling MQTT sparkplug metrics of type `Dataset`. 
It uses `valueJson`, which was previously unused.
I have introduced the optional property `samplingRate`.

Handling of `Dataset` metrics work, but I am not sure if this could interfer with the other drivers, which I am not using, or if I am not using `valueJson` the way it was intended to be.