### PR TITLE
fix: isNull undefined and unused

### DIFF
--- a/src/mqtt-sparkplug/index.js
+++ b/src/mqtt-sparkplug/index.js
@@ -1773,6 +1773,7 @@ function queueMetric(metric, deviceLocator, isBirth, templateName) {
     valueJson = {},
     type = 'digital',
     invalid = false,
+    isNull = false,
     timestamp,
     timestampGood = true,
     catalogProperties = {},
@@ -2014,7 +2015,7 @@ function queueMetric(metric, deviceLocator, isBirth, templateName) {
     timeTagAtSource: new Date(timestamp),
     timeTagAtSourceOk: timestampGood,
     asduAtSource: type,
-    isNull: metric?.isNull === true,
+    isNull: isNull,
     ...catalogProperties,
   })
 }


### PR DESCRIPTION
isNull was undefined in queueMetric and later modified if value was null or metric.isNull was true, but it is later not used and only uses a part of the condition. Fixed it just by declaring isNull and using it in queue