### PR TITLE
Fix environment variables for NodeJS services

### DIFF
--- a/src/OPC-UA-Server/load-config.js
+++ b/src/OPC-UA-Server/load-config.js
@@ -50,7 +50,7 @@ function LoadConfig () {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (args.length > 1) Log.levelCurrent = parseInt(args[1])
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/OPC-UA-Server/load-config.js
+++ b/src/OPC-UA-Server/load-config.js
@@ -57,7 +57,7 @@ function LoadConfig () {
   var instArg = null
   if (args.length > 0) instArg = parseInt(args[0])
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/alarm_beep/load-config.js
+++ b/src/alarm_beep/load-config.js
@@ -85,7 +85,7 @@ function LoadConfig() {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (args.length > 1) Log.levelCurrent = parseInt(args[1])
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/alarm_beep/load-config.js
+++ b/src/alarm_beep/load-config.js
@@ -92,7 +92,7 @@ function LoadConfig() {
   var instArg = null
   if (args.length > 0) instArg = parseInt(args[0])
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/backup-mongo/load-config.js
+++ b/src/backup-mongo/load-config.js
@@ -51,7 +51,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
   configObj.LogLevel = Log.levelCurrent
 
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/backup-mongo/load-config.js
+++ b/src/backup-mongo/load-config.js
@@ -46,7 +46,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (logLevelArg) Log.levelCurrent = parseInt(logLevelArg)
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/carbone-reports/load-config.js
+++ b/src/carbone-reports/load-config.js
@@ -50,7 +50,7 @@ function LoadConfig () {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (args.length > 1) Log.levelCurrent = parseInt(args[1])
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/carbone-reports/load-config.js
+++ b/src/carbone-reports/load-config.js
@@ -57,7 +57,7 @@ function LoadConfig () {
   var instArg = null
   if (args.length > 0) instArg = parseInt(args[0])
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/config_server_for_excel/load-config.js
+++ b/src/config_server_for_excel/load-config.js
@@ -50,7 +50,7 @@ function LoadConfig () {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (args.length > 1) Log.levelCurrent = parseInt(args[1])
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/config_server_for_excel/load-config.js
+++ b/src/config_server_for_excel/load-config.js
@@ -57,7 +57,7 @@ function LoadConfig () {
   var instArg = null
   if (args.length > 0) instArg = parseInt(args[0])
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/cs_custom_processor/app-defs.js
+++ b/src/cs_custom_processor/app-defs.js
@@ -19,7 +19,7 @@
 
 module.exports = {
   NAME: 'CS_CUSTOM_PROCESSOR',
-  ENV_PREFIX: 'JS_CS_CUSTOM_PROCESSOR',
+  ENV_PREFIX: 'JS_CSCUSTOMPROC_',
   MSG: '{json:scada} - Change Stream Custom Processor',
   VERSION: '0.1.2',
 }

--- a/src/cs_custom_processor/load-config.js
+++ b/src/cs_custom_processor/load-config.js
@@ -51,7 +51,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
   configObj.LogLevel = Log.levelCurrent
 
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/cs_custom_processor/load-config.js
+++ b/src/cs_custom_processor/load-config.js
@@ -46,7 +46,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (logLevelArg) Log.levelCurrent = parseInt(logLevelArg)
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/cs_data_processor/app-defs.js
+++ b/src/cs_data_processor/app-defs.js
@@ -19,7 +19,7 @@
 
 module.exports = {
   NAME: 'CS_DATA_PROCESSOR',
-  ENV_PREFIX: 'JS_CS_DATA_PROCESSOR',
+  ENV_PREFIX: 'JS_CSDATAPROC_',
   MSG: '{json:scada} - Change Stream Data Processor',
   VERSION: '0.1.4',
 }

--- a/src/cs_data_processor/load-config.js
+++ b/src/cs_data_processor/load-config.js
@@ -51,7 +51,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
   configObj.LogLevel = Log.levelCurrent
 
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/cs_data_processor/load-config.js
+++ b/src/cs_data_processor/load-config.js
@@ -46,7 +46,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (logLevelArg) Log.levelCurrent = parseInt(logLevelArg)
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/demo_simul/load-config.js
+++ b/src/demo_simul/load-config.js
@@ -85,7 +85,7 @@ function LoadConfig() {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (args.length > 1) Log.levelCurrent = parseInt(args[1])
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/demo_simul/load-config.js
+++ b/src/demo_simul/load-config.js
@@ -92,7 +92,7 @@ function LoadConfig() {
   var instArg = null
   if (args.length > 0) instArg = parseInt(args[0])
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/mongofw/load-config.js
+++ b/src/mongofw/load-config.js
@@ -50,7 +50,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
   configObj.LogLevel = Log.levelCurrent
 
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/mongofw/load-config.js
+++ b/src/mongofw/load-config.js
@@ -45,7 +45,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (logLevelArg) Log.levelCurrent = parseInt(logLevelArg)
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/mongowr/load-config.js
+++ b/src/mongowr/load-config.js
@@ -50,7 +50,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
   configObj.LogLevel = Log.levelCurrent
 
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/mongowr/load-config.js
+++ b/src/mongowr/load-config.js
@@ -45,7 +45,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (logLevelArg) Log.levelCurrent = parseInt(logLevelArg)
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/mqtt-sparkplug/load-config.js
+++ b/src/mqtt-sparkplug/load-config.js
@@ -50,7 +50,7 @@ function LoadConfig () {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (args.length > 1) Log.levelCurrent = parseInt(args[1])
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/mqtt-sparkplug/load-config.js
+++ b/src/mqtt-sparkplug/load-config.js
@@ -57,7 +57,7 @@ function LoadConfig () {
   var instArg = null
   if (args.length > 0) instArg = parseInt(args[0])
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/server_realtime_auth/load-config.js
+++ b/src/server_realtime_auth/load-config.js
@@ -51,7 +51,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
   configObj.LogLevel = Log.levelCurrent
 
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/server_realtime_auth/load-config.js
+++ b/src/server_realtime_auth/load-config.js
@@ -46,7 +46,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (logLevelArg) Log.levelCurrent = parseInt(logLevelArg)
   configObj.LogLevel = Log.levelCurrent
 

--- a/src/updateUser/load-config.js
+++ b/src/updateUser/load-config.js
@@ -51,7 +51,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
   configObj.LogLevel = Log.levelCurrent
 
   configObj.Instance =
-    instArg || process.env[AppDefs.ENV_PREFIX + 'INSTANCE'] || 1
+    instArg || parseInt(process.env[AppDefs.ENV_PREFIX + 'INSTANCE']) || 1
 
   configObj.GridFsCollectionName = 'files'
   configObj.RealtimeDataCollectionName = 'realtimeData'

--- a/src/updateUser/load-config.js
+++ b/src/updateUser/load-config.js
@@ -46,7 +46,7 @@ function LoadConfig (confFileArg, logLevelArg, instArg) {
 
   Log.levelCurrent = Log.levelNormal
   if (AppDefs.ENV_PREFIX + 'LOGLEVEL' in process.env)
-    Log.levelCurrent = process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL']
+    Log.levelCurrent = parseInt(process.env[AppDefs.ENV_PREFIX + 'LOGLEVEL'])
   if (logLevelArg) Log.levelCurrent = parseInt(logLevelArg)
   configObj.LogLevel = Log.levelCurrent
 


### PR DESCRIPTION
I came across a few issues as I tried running `cs_data_processor`, `cs_custom_processor`, and `mqtt-sparkplug` passing environment variables as described in their respective READMEs.

## `cs_data_processor`
[Environment variables](https://github.com/riclolsen/json-scada/blob/master/src/cs_data_processor/README.md#process-command-line-arguments-and-environment-variables) `JS_CSDATAPROC_INSTANCE` and `JS_CSDATAPROC_LOGLEVEL` were ignored (because [`ENV_PREFIX`](https://github.com/riclolsen/json-scada/blob/master/src/cs_data_processor/app-defs.js#L22) does not match)

## `cs_custom_processor`
[Environment variables](https://github.com/riclolsen/json-scada/blob/master/src/cs_custom_processor/README.md#process-command-line-arguments-and-environment-variables) `JS_CSCUSTOMPROC_INSTANCE` and `JS_CSCUSTOMPROC_LOGLEVEL` were ignored (because [`ENV_PREFIX`](https://github.com/riclolsen/json-scada/blob/master/src/cs_custom_processor/app-defs.js#L22) does not match)

## `mqtt-sparkplug`
The environment variables for this process are `JS_MQTTSPB_INSTANCE` and `JS_MQTTSPB_LOGLEVEL`.
They match `ENV_PREFIX`, however they are not parsed as Integers, and the process crashes with the following error message
```
2024-08-01T13:55:30.486Z - Config - Config File: ../../conf/json-scada.json
2024-08-01T13:55:30.489Z - Config - {json:scada} - MQTT-Sparkplug-B Client Driver Version 0.1.6
2024-08-01T13:55:30.490Z - Config - Instance: 1
2024-08-01T13:55:30.490Z - Config - Log level: 3
2024-08-01T13:55:30.491Z - MongoDB - Connecting to MongoDB server...
2024-08-01T13:55:30.542Z - MongoDB - Connected correctly to MongoDB server
2024-08-01T13:55:30.567Z - Connection - No protocol connection found!
```
[`getConnection`](https://github.com/riclolsen/json-scada/blob/master/src/mqtt-sparkplug/index.js#L897) fails because `protocolDriverInstanceNumber` is expected to be numeric rather than a string. As a result, no connection number can be found.

---
All this PR does is:
- cast environment variables `*_INSTANCE` and `*_LOGLEVEL` as integers
- use the proper prefixes for `cs_*_processor`