### PR TITLE
use correct framework

### DIFF
--- a/src/libiec61850/dotnet/core/2.0/iec61850_client/iec61850_client.csproj
+++ b/src/libiec61850/dotnet/core/2.0/iec61850_client/iec61850_client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks