### PR TITLE
changed data type of  peerCertFilesPaths  from String to String[ ] to allow multiple Certificate file paths in iec61850 Client driver

### DIFF
--- a/src/libiec61850/dotnet/core/2.0/iec61850_client/Common_srv_cli.cs
+++ b/src/libiec61850/dotnet/core/2.0/iec61850_client/Common_srv_cli.cs
@@ -103,8 +103,8 @@ namespace IEC61850_Client
             public bool useSecurity { get; set; }
             [BsonDefaultValue("")]
             public string localCertFilePath { get; set; }
-            [BsonDefaultValue("")]
-            public string peerCertFilesPaths { get; set; }
+            [BsonDefaultValue(new string[] { })]
+            public string[] peerCertFilesPaths { get; set; }
             [BsonDefaultValue("")]
             public string rootCertFilePath { get; set; }
             [BsonDefaultValue(false)]


### PR DESCRIPTION
In IEC 61850 client driver in  "src/libiec61850/dotnet/core/2.0/iec61850_client/Common_srv_cli.cs" file, Line 107 
 public string PeerCertFilesPaths { get; set; }  is changed to   public string[] PeerCertFilesPaths { get; set; } to allow multiple certificates.